### PR TITLE
Fix: Adds 'unstoppable_nodelets' param to example

### DIFF
--- a/universal_robot_dynident/config/binary_logger.yaml
+++ b/universal_robot_dynident/config/binary_logger.yaml
@@ -5,6 +5,9 @@ binary_logger:
 
   # manager_name: name of the nodlet manager (need to be equal to the name in the launch file)
   manager_name: 'binary_logger'
+  
+  # list of nodelet (unrelated to binary_logger package) that the user do not want to stop
+  unstoppable_nodelets: []
 
   # Type of the topic that need to be logged (supported JointState, Imu, PoseStamped, WrenchStamped, Float64MultiArray)
   topic_type:


### PR DESCRIPTION
"binary_logger" exits ungracefully if this parameter is not specified. This leads to binary files that are not flushed and that will be rejected by ROSdyn when being loaded for model estimation.